### PR TITLE
Always read labelling config from the `master` branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ async function fetchConfig (
     owner,
     repo,
     path: filepath,
-    ref: github.context.sha
+    ref: 'master'
   })
 
   return Buffer.from(response.data.content, response.data.encoding).toString()


### PR DESCRIPTION
Instead of reading the labelling config from the target branch/SHA, which for the nodejs/node project might be a staging branch.

As observed by @targos, always having to cherry-pick labelling config changes merged to the master branch, into different staging branches is very inconvenient and will be forgotten from time to time.

Let's instead *always* read the labelling config from the master branch.

Refs https://github.com/nodejs/node/pull/38301#issuecomment-826267001

/cc @nodejs/github-bot 