### PR TITLE
Use `$default-branch` allowing for easier transition from master -> main

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ async function fetchConfig (
     owner,
     repo,
     path: filepath,
-    ref: 'master'
+    ref: github.context.payload.pull_request.base.repo.default_branch
   })
 
   return Buffer.from(response.data.content, response.data.encoding).toString()


### PR DESCRIPTION
As opposed to *always* fetching the labelling config from the `master` branch, this change will use the repository' configured default branch.

Refs https://github.com/nodejs/github-bot/issues/302

/cc @nodejs/github-bot @mhdawson @targos 